### PR TITLE
chore(nginx): remove server tokens

### DIFF
--- a/deployment-scripts/setup.sh
+++ b/deployment-scripts/setup.sh
@@ -109,6 +109,7 @@ function setup_nginx_and_ssl() {
 server {
     listen 80;
     server_name www.govex.ai govex.ai;
+    server_tokens off;
 
     if (\$host = govex.ai) {
         return 301 https://www.govex.ai\$request_uri;


### PR DESCRIPTION
This change will remove nginx version from being displayed on error pages 
<img width="338" alt="image" src="https://github.com/user-attachments/assets/f9dbb3fe-8a8b-453e-be68-0bb5991c6a04" />
