### PR TITLE
set-twap-start-time-to-trading-start-time

### DIFF
--- a/contracts/futarchy/sources/amm/amm.move
+++ b/contracts/futarchy/sources/amm/amm.move
@@ -281,9 +281,9 @@ fun write_observation(oracle: &mut Oracle, timestamp: u64, price: u128) {
     oracle::write_observation(oracle, timestamp, price)
 }
 
-public(package) fun write_current_price_observation(pool: &mut LiquidityPool, timestamp: u64) {
+public(package) fun write_current_price_observation(pool: &mut LiquidityPool, clock: &Clock) {
     let current_price = get_current_price(pool);
-    oracle::write_observation(&mut pool.oracle, timestamp, current_price);
+    oracle::write_observation(&mut pool.oracle, clock::timestamp_ms(clock), current_price);
 }
 
 public fun get_oracle(pool: &LiquidityPool): &Oracle {

--- a/contracts/futarchy/sources/amm/amm.move
+++ b/contracts/futarchy/sources/amm/amm.move
@@ -63,7 +63,6 @@ public(package) fun new_pool(
     twap_initial_observation: u128,
     twap_start_delay: u64,
     twap_step_max: u64,
-    start_time: u64,
     ctx: &mut TxContext,
 ): LiquidityPool {
     assert!(initial_asset > 0 && initial_stable > 0, EZERO_AMOUNT);
@@ -79,7 +78,6 @@ public(package) fun new_pool(
     // Initialize oracle
     let oracle = oracle::new_oracle(
         twap_initialization_price,
-        start_time,
         twap_start_delay,
         twap_step_max,
         ctx, // Add ctx parameter here
@@ -440,7 +438,6 @@ public fun create_test_pool(
         fee_percent: DEFAULT_FEE,
         oracle: oracle::new_oracle(
             math::mul_div_to_128(stable_reserve, 1_000_000_000_000, asset_reserve),
-            0, // market start time
             2_000,
             1_000,
             ctx, // Add ctx parameter here

--- a/contracts/futarchy/sources/amm/amm.move
+++ b/contracts/futarchy/sources/amm/amm.move
@@ -76,17 +76,12 @@ public(package) fun new_pool(
     check_price_under_max(twap_initialization_price);
 
     // Initialize oracle
-    let mut oracle = oracle::new_oracle(
+    let oracle = oracle::new_oracle(
         twap_initialization_price,
         start_time,
         twap_start_delay,
         twap_step_max,
         ctx, // Add ctx parameter here
-    );
-    oracle::write_observation(
-        &mut oracle,
-        start_time,
-        initial_price,
     );
 
     // Create pool object as usual
@@ -286,6 +281,11 @@ fun write_observation(oracle: &mut Oracle, timestamp: u64, price: u128) {
     oracle::write_observation(oracle, timestamp, price)
 }
 
+public(package) fun write_current_price_observation(pool: &mut LiquidityPool, timestamp: u64) {
+    let current_price = get_current_price(pool);
+    oracle::write_observation(&mut pool.oracle, timestamp, current_price);
+}
+
 public fun get_oracle(pool: &LiquidityPool): &Oracle {
     &pool.oracle
 }
@@ -354,6 +354,11 @@ public(package) fun update_twap_observation(pool: &mut LiquidityPool, clock: &Cl
     let current_price = get_current_price(pool);
     // Use the sum of reserves as a liquidity measure
     oracle::write_observation(&mut pool.oracle, timestamp, current_price);
+}
+
+
+public(package) fun set_oracle_start_time(pool: &mut LiquidityPool, market_start_time: u64) {
+    oracle::set_oracle_start_time(&mut pool.oracle, market_start_time);
 }
 
 // ======== Internal Functions ========

--- a/contracts/futarchy/sources/amm/amm.move
+++ b/contracts/futarchy/sources/amm/amm.move
@@ -19,7 +19,6 @@ const EZERO_LIQUIDITY: u64 = 4;
 const EPRICE_TOO_HIGH: u64 = 5;
 const EZERO_AMOUNT: u64 = 6;
 const EMARKET_ID_MISMATCH: u64 = 7;
-const EOBSERVATION_NOT_AT_START: u64 = 8;
 
 // === Constants ===
 const FEE_SCALE: u64 = 10000;

--- a/contracts/futarchy/sources/amm/amm.move
+++ b/contracts/futarchy/sources/amm/amm.move
@@ -282,10 +282,14 @@ fun write_observation(oracle: &mut Oracle, timestamp: u64, price: u128) {
     oracle::write_observation(oracle, timestamp, price)
 }
 
-public(package) fun write_initial_price_observation(pool: &mut LiquidityPool, clock: &Clock, ms: &MarketState) {
+public(package) fun write_initial_price_observation(
+    pool: &mut LiquidityPool,
+    clock: &Clock,
+    ms: &MarketState,
+) {
     let current_time = clock::timestamp_ms(clock);
     let trading_start = market_state::get_trading_start(ms);
-    
+
     // Ensure this function is only called at the exact moment trading starts
     assert!(current_time == trading_start, EOBSERVATION_NOT_AT_START);
     let current_price = get_current_price(pool);
@@ -361,7 +365,6 @@ public(package) fun update_twap_observation(pool: &mut LiquidityPool, clock: &Cl
     // Use the sum of reserves as a liquidity measure
     oracle::write_observation(&mut pool.oracle, timestamp, current_price);
 }
-
 
 public(package) fun set_oracle_start_time(pool: &mut LiquidityPool, market_start_time: u64) {
     oracle::set_oracle_start_time(&mut pool.oracle, market_start_time);

--- a/contracts/futarchy/sources/amm/amm.move
+++ b/contracts/futarchy/sources/amm/amm.move
@@ -280,20 +280,6 @@ fun write_observation(oracle: &mut Oracle, timestamp: u64, price: u128) {
     oracle::write_observation(oracle, timestamp, price)
 }
 
-public(package) fun write_initial_price_observation(
-    pool: &mut LiquidityPool,
-    clock: &Clock,
-    ms: &MarketState,
-) {
-    let current_time = clock::timestamp_ms(clock);
-    let trading_start = market_state::get_trading_start(ms);
-
-    // Ensure this function is only called at the exact moment trading starts
-    assert!(current_time == trading_start, EOBSERVATION_NOT_AT_START);
-    let current_price = get_current_price(pool);
-    oracle::write_observation(&mut pool.oracle, current_time, current_price);
-}
-
 public fun get_oracle(pool: &LiquidityPool): &Oracle {
     &pool.oracle
 }

--- a/contracts/futarchy/sources/amm/amm.move
+++ b/contracts/futarchy/sources/amm/amm.move
@@ -349,8 +349,10 @@ public(package) fun update_twap_observation(pool: &mut LiquidityPool, clock: &Cl
     oracle::write_observation(&mut pool.oracle, timestamp, current_price);
 }
 
-public(package) fun set_oracle_start_time(pool: &mut LiquidityPool, market_start_time: u64) {
-    oracle::set_oracle_start_time(&mut pool.oracle, market_start_time);
+public(package) fun set_oracle_start_time(pool: &mut LiquidityPool, state: &MarketState) {
+    assert!(get_ms_id(pool) == market_state::market_id(state), EMARKET_ID_MISMATCH);
+    let trading_start_time = market_state::get_trading_start(state);
+    oracle::set_oracle_start_time(&mut pool.oracle, trading_start_time);
 }
 
 // ======== Internal Functions ========
@@ -399,6 +401,10 @@ public fun check_price_under_max(price: u128) {
 
 public(package) fun get_protocol_fees(pool: &LiquidityPool): u64 {
     pool.protocol_fees
+}
+
+public(package) fun get_ms_id(pool: &LiquidityPool): ID {
+    pool.market_id
 }
 
 public(package) fun reset_protocol_fees(pool: &mut LiquidityPool) {

--- a/contracts/futarchy/sources/amm/liquidity_initialize.move
+++ b/contracts/futarchy/sources/amm/liquidity_initialize.move
@@ -25,7 +25,6 @@ public(package) fun create_outcome_markets<AssetType, StableType>(
     twap_start_delay: u64,
     twap_initial_observation: u128,
     twap_step_max: u64,
-    creation_time: u64,
     initial_asset: Balance<AssetType>,
     initial_stable: Balance<StableType>,
     clock: &Clock,
@@ -85,7 +84,6 @@ public(package) fun create_outcome_markets<AssetType, StableType>(
                 twap_initial_observation,
                 twap_start_delay,
                 twap_step_max,
-                creation_time,
                 ctx,
             );
             vector::push_back(&mut amm_pools, pool);

--- a/contracts/futarchy/sources/amm/oracle.move
+++ b/contracts/futarchy/sources/amm/oracle.move
@@ -62,7 +62,6 @@ public struct PriceEvent has copy, drop {
 // ======== Constructor ========
 public(package) fun new_oracle(
     twap_initialization_price: u128,
-    market_start_time: u64,
     twap_start_delay: u64,
     twap_cap_step: u64,
     ctx: &mut TxContext,
@@ -492,7 +491,6 @@ public fun debug_get_state(oracle: &Oracle): (u128, u64, u256) {
 public fun test_oracle(ctx: &mut TxContext): Oracle {
     new_oracle(
         10000, // twap_initialization_price
-        0, // market_start_time
         60_000, // twap_start_delay
         1000, // max_bps_per_step
         ctx, // sixth argument (TxContext)

--- a/contracts/futarchy/sources/amm/oracle.move
+++ b/contracts/futarchy/sources/amm/oracle.move
@@ -83,7 +83,7 @@ public(package) fun new_oracle(
         last_window_twap: twap_initialization_price,
         twap_start_delay: twap_start_delay,
         twap_cap_step: twap_cap_step,
-        market_start_time: option::none(), // should proably be nullable
+        market_start_time: option::none(), // nullable so that TWAP is not valid if not properly initialized
         twap_initialization_price: twap_initialization_price,
     }
 }

--- a/contracts/futarchy/sources/amm/oracle.move
+++ b/contracts/futarchy/sources/amm/oracle.move
@@ -450,7 +450,7 @@ public(package) fun set_oracle_start_time(oracle: &mut Oracle, market_start_time
     oracle.market_start_time = option::some(market_start_time_param);
     oracle.last_window_end = market_start_time_param;
     oracle.last_timestamp = market_start_time_param;
- }
+}
 
 // ======== Getters ========
 public fun get_last_price(oracle: &Oracle): u128 {

--- a/contracts/futarchy/sources/amm/oracle.move
+++ b/contracts/futarchy/sources/amm/oracle.move
@@ -31,7 +31,7 @@ const EOVERFLOW_V_SUM_PRICES_ADD: u64 = 11;
 const EINTERNAL_TWAP_ERROR: u64 = 12;
 const E_NONE_FULL_WINDOW_TWAP_DELAY: u64 = 13;
 const E_MARKET_NOT_STARTED: u64 = 14;
-const E_MARKET_ALREADY_STARTED: u64 = 14;
+const E_MARKET_ALREADY_STARTED: u64 = 15;
 
 // ======== Configuration Struct ========
 public struct Oracle has key, store {

--- a/contracts/futarchy/sources/amm/oracle.move
+++ b/contracts/futarchy/sources/amm/oracle.move
@@ -75,14 +75,14 @@ public(package) fun new_oracle(
     Oracle {
         id: object::new(ctx), // Create a unique ID for the oracle
         last_price: twap_initialization_price,
-        last_timestamp: market_start_time,
+        last_timestamp: 0, // set to current time when trading starts
         total_cumulative_price: 0,
         last_window_end_cumulative_price: 0,
-        last_window_end: market_start_time,
+        last_window_end: 0, // set to current time when trading starts
         last_window_twap: twap_initialization_price,
         twap_start_delay: twap_start_delay,
         twap_cap_step: twap_cap_step,
-        market_start_time: market_start_time,
+        market_start_time: 0, // set to current time when trading starts
         twap_initialization_price: twap_initialization_price,
     }
 }
@@ -436,6 +436,12 @@ public(package) fun get_twap(oracle: &Oracle, clock: &Clock): u128 {
     let twap = (oracle.total_cumulative_price) / (period as u256);
 
     (twap as u128)
+}
+
+public(package) fun set_oracle_start_time(oracle: &mut Oracle, market_start_time: u64) {
+    oracle.market_start_time = market_start_time;
+    oracle.last_window_end = market_start_time;
+    oracle.last_timestamp = market_start_time;
 }
 
 // ======== Getters ========

--- a/contracts/futarchy/sources/amm/oracle.move
+++ b/contracts/futarchy/sources/amm/oracle.move
@@ -465,6 +465,10 @@ public fun get_twap_initialization_price(oracle: &Oracle): u128 {
     oracle.twap_initialization_price // Access through config
 }
 
+public fun get_total_cumulative_price(oracle: &Oracle): u256 {
+    oracle.total_cumulative_price
+}
+
 public fun get_id(o: &Oracle): &UID {
     &o.id
 }

--- a/contracts/futarchy/sources/core/proposal.move
+++ b/contracts/futarchy/sources/core/proposal.move
@@ -196,7 +196,6 @@ public(package) fun create<AssetType, StableType>(
         twap_start_delay,
         twap_initial_observation,
         twap_step_max,
-        clock::timestamp_ms(clock),
         initial_asset,
         initial_stable,
         clock,

--- a/contracts/futarchy/sources/utils/advance_stage.move
+++ b/contracts/futarchy/sources/utils/advance_stage.move
@@ -65,6 +65,17 @@ public(package) fun try_advance_state<AssetType, StableType>(
     ) {
         proposal::set_state(proposal, STATE_TRADING);
         market_state::start_trading(state, proposal::get_trading_period_ms(proposal), clock);
+        let trading_start = market_state::get_trading_start(state);
+        let pools_count = vector::length(proposal::get_amm_pools(proposal));
+        let mut i = 0;
+        while (i < pools_count) {
+            let pool = proposal::get_pool_mut_by_outcome(proposal, (i as u8));
+            amm::set_oracle_start_time(pool, trading_start);
+            // Write the first observation at trading start
+            // Then write a fresh observation at the trading start time
+            amm::write_current_price_observation(pool, trading_start);
+            i = i + 1;
+        };
     } else if (proposal::state(proposal) == STATE_TRADING) {
         let configured_trading_end_option = market_state::get_trading_end_time(state);
         assert!(current_time >= *option::borrow(&configured_trading_end_option), EIN_TRADIG_PERIOD);

--- a/contracts/futarchy/sources/utils/advance_stage.move
+++ b/contracts/futarchy/sources/utils/advance_stage.move
@@ -127,9 +127,6 @@ fun initialize_oracles_for_trading<AssetType, StableType>(
     while (i < pools_count) {
         let pool = proposal::get_pool_mut_by_outcome(proposal, (i as u8));
         amm::set_oracle_start_time(pool, trading_start);
-        // Write the first observation at trading start
-        // Then write a fresh observation at the trading start time
-        amm::write_initial_price_observation(pool, clock, state);
         i = i + 1;
     };
 }

--- a/contracts/futarchy/sources/utils/advance_stage.move
+++ b/contracts/futarchy/sources/utils/advance_stage.move
@@ -65,7 +65,7 @@ public(package) fun try_advance_state<AssetType, StableType>(
     ) {
         proposal::set_state(proposal, STATE_TRADING);
         market_state::start_trading(state, proposal::get_trading_period_ms(proposal), clock);
-        initialize_oracles_for_trading(proposal, state, clock);
+        initialize_oracles_for_trading(proposal, state);
     } else if (proposal::state(proposal) == STATE_TRADING) {
         let configured_trading_end_option = market_state::get_trading_end_time(state);
         assert!(current_time >= *option::borrow(&configured_trading_end_option), EIN_TRADIG_PERIOD);
@@ -119,14 +119,12 @@ public entry fun try_advance_state_entry<AssetType, StableType>(
 fun initialize_oracles_for_trading<AssetType, StableType>(
     proposal: &mut Proposal<AssetType, StableType>,
     state: &MarketState,
-    clock: &Clock,
 ) {
-    let trading_start = market_state::get_trading_start(state);
     let pools_count = vector::length(proposal::get_amm_pools(proposal));
     let mut i = 0;
     while (i < pools_count) {
         let pool = proposal::get_pool_mut_by_outcome(proposal, (i as u8));
-        amm::set_oracle_start_time(pool, trading_start);
+        amm::set_oracle_start_time(pool, state);
         i = i + 1;
     };
 }

--- a/contracts/futarchy/sources/utils/advance_stage.move
+++ b/contracts/futarchy/sources/utils/advance_stage.move
@@ -129,7 +129,7 @@ fun initialize_oracles_for_trading<AssetType, StableType>(
         amm::set_oracle_start_time(pool, trading_start);
         // Write the first observation at trading start
         // Then write a fresh observation at the trading start time
-        amm::write_current_price_observation(pool, clock);
+        amm::write_initial_price_observation(pool, clock, state);
         i = i + 1;
     };
 }

--- a/contracts/futarchy/sources/utils/market_state.move
+++ b/contracts/futarchy/sources/utils/market_state.move
@@ -193,6 +193,10 @@ public fun get_creation_time(state: &MarketState): u64 {
 public(package) fun get_trading_end_time(state: &MarketState): Option<u64> {
     state.trading_end
 }
+
+public fun get_trading_start(state: &MarketState): u64 {
+    state.trading_start
+}
 // === Test Functions ===
 #[test_only]
 public fun create_for_testing(outcomes: u64, ctx: &mut TxContext): MarketState {

--- a/contracts/futarchy/tests/amm/amm_aditional_tests.move
+++ b/contracts/futarchy/tests/amm/amm_aditional_tests.move
@@ -72,7 +72,6 @@ fun setup_pool(scenario: &mut Scenario, state: &MarketState, clock: &Clock): Liq
         (BASIS_POINTS as u128),
         TWAP_START_DELAY,
         TWAP_STEP_MAX,
-        clock::timestamp_ms(clock),
         ctx(scenario),
     )
 }
@@ -233,7 +232,6 @@ fun test_price_calculation_accuracy() {
             (BASIS_POINTS as u128),
             TWAP_START_DELAY,
             TWAP_STEP_MAX,
-            clock::timestamp_ms(&clock),
             ctx(&mut scenario),
         );
         
@@ -259,7 +257,6 @@ fun test_price_calculation_accuracy() {
             (BASIS_POINTS as u128),
             TWAP_START_DELAY,
             TWAP_STEP_MAX,
-            clock::timestamp_ms(&clock),
             ctx(&mut scenario),
         );
         
@@ -569,7 +566,6 @@ fun test_pool_id_and_outcome() {
         (BASIS_POINTS as u128),
         TWAP_START_DELAY,
         TWAP_STEP_MAX,
-        clock::timestamp_ms(&clock),
         ctx(&mut scenario),
     );
     
@@ -581,7 +577,6 @@ fun test_pool_id_and_outcome() {
         (BASIS_POINTS as u128),
         TWAP_START_DELAY,
         TWAP_STEP_MAX,
-        clock::timestamp_ms(&clock),
         ctx(&mut scenario),
     );
     
@@ -625,7 +620,6 @@ fun test_minimal_liquidity() {
         (BASIS_POINTS as u128),
         TWAP_START_DELAY,
         TWAP_STEP_MAX,
-        clock::timestamp_ms(&clock),
         ctx(&mut scenario),
     );
     
@@ -669,7 +663,6 @@ fun test_max_price() {
         (BASIS_POINTS as u128),
         TWAP_START_DELAY,
         TWAP_STEP_MAX,
-        clock::timestamp_ms(&clock),
         ctx(&mut scenario),
     );
     
@@ -735,7 +728,6 @@ fun test_min_liquidity_requirement() {
         (BASIS_POINTS as u128),
         TWAP_START_DELAY,
         TWAP_STEP_MAX,
-        clock::timestamp_ms(&clock),
         ctx(&mut scenario),
     );
     

--- a/contracts/futarchy/tests/amm/amm_aditional_tests.move
+++ b/contracts/futarchy/tests/amm/amm_aditional_tests.move
@@ -75,7 +75,7 @@ fun setup_pool(scenario: &mut Scenario, state: &MarketState, clock: &Clock): Liq
         ctx(scenario),
     );
 
-    amm::set_oracle_start_time(&mut  pool_inst, clock::timestamp_ms(clock));
+    amm::set_oracle_start_time(&mut  pool_inst, state);
     pool_inst
 }
 

--- a/contracts/futarchy/tests/amm/amm_aditional_tests.move
+++ b/contracts/futarchy/tests/amm/amm_aditional_tests.move
@@ -64,7 +64,7 @@ fun setup_market(scenario: &mut Scenario, clock: &Clock): (MarketState) {
 }
 
 fun setup_pool(scenario: &mut Scenario, state: &MarketState, clock: &Clock): LiquidityPool {
-    amm::new_pool(
+    let mut pool_inst = amm::new_pool(
         state,
         0, // outcome_idx
         INITIAL_ASSET,
@@ -73,7 +73,10 @@ fun setup_pool(scenario: &mut Scenario, state: &MarketState, clock: &Clock): Liq
         TWAP_START_DELAY,
         TWAP_STEP_MAX,
         ctx(scenario),
-    )
+    );
+
+    amm::set_oracle_start_time(&mut  pool_inst, clock::timestamp_ms(clock));
+    pool_inst
 }
 
 // ======== K-Invariant Tests ========

--- a/contracts/futarchy/tests/amm/amm_tests.move
+++ b/contracts/futarchy/tests/amm/amm_tests.move
@@ -70,7 +70,7 @@ fun setup_pool(scenario: &mut Scenario, state: &MarketState, clock: &Clock): Liq
         ctx(scenario),
     );
 
-    amm::set_oracle_start_time(&mut  pool_inst, clock::timestamp_ms(clock));
+    amm::set_oracle_start_time(&mut  pool_inst, state);
     pool_inst
 }
 

--- a/contracts/futarchy/tests/amm/amm_tests.move
+++ b/contracts/futarchy/tests/amm/amm_tests.move
@@ -59,7 +59,7 @@ fun setup_market(scenario: &mut Scenario, clock: &Clock): (MarketState) {
 }
 
 fun setup_pool(scenario: &mut Scenario, state: &MarketState, clock: &Clock): LiquidityPool {
-    amm::new_pool(
+    let mut pool_inst = amm::new_pool(
         state,
         0, // outcome_idx
         INITIAL_ASSET,
@@ -68,7 +68,10 @@ fun setup_pool(scenario: &mut Scenario, state: &MarketState, clock: &Clock): Liq
         TWAP_START_DELAY,
         TWAP_STEP_MAX,
         ctx(scenario),
-    )
+    );
+
+    amm::set_oracle_start_time(&mut  pool_inst, clock::timestamp_ms(clock));
+    pool_inst
 }
 
 // ======== Basic Functionality Tests ========

--- a/contracts/futarchy/tests/amm/amm_tests.move
+++ b/contracts/futarchy/tests/amm/amm_tests.move
@@ -67,7 +67,6 @@ fun setup_pool(scenario: &mut Scenario, state: &MarketState, clock: &Clock): Liq
         (BASIS_POINTS as u128),
         TWAP_START_DELAY,
         TWAP_STEP_MAX,
-        clock::timestamp_ms(clock),
         ctx(scenario),
     )
 }

--- a/contracts/futarchy/tests/amm/oracle_integration_tests/oracle_burst_tests.move
+++ b/contracts/futarchy/tests/amm/oracle_integration_tests/oracle_burst_tests.move
@@ -22,7 +22,6 @@ const U64_MAX: u64 = 18446744073709551615;
 fun setup_test_oracle(ctx: &mut TxContext): Oracle {
     oracle::new_oracle(
         INIT_PRICE,
-        MARKET_START_TIME,
         TWAP_START_DELAY,
         TWAP_STEP_MAX,
         ctx,

--- a/contracts/futarchy/tests/amm/oracle_integration_tests/oracle_burst_tests.move
+++ b/contracts/futarchy/tests/amm/oracle_integration_tests/oracle_burst_tests.move
@@ -20,12 +20,14 @@ const U64_MAX: u64 = 18446744073709551615;
 
 // ======== Helper Functions ========
 fun setup_test_oracle(ctx: &mut TxContext): Oracle {
-    oracle::new_oracle(
+    let mut oracle_inst = oracle::new_oracle(
         INIT_PRICE,
         TWAP_START_DELAY,
         TWAP_STEP_MAX,
         ctx,
-    )
+    );
+    oracle::set_oracle_start_time(&mut oracle_inst, MARKET_START_TIME);
+    oracle_inst
 }
 
 fun setup_scenario_and_clock(): (Scenario, clock::Clock) {

--- a/contracts/futarchy/tests/amm/oracle_integration_tests/oracle_full_proposal_twap_time_test.move
+++ b/contracts/futarchy/tests/amm/oracle_integration_tests/oracle_full_proposal_twap_time_test.move
@@ -1,0 +1,190 @@
+#[test_only]
+module futarchy::oracle_full_proposal_twap_time_test;
+
+// === Imports ===
+use sui::test_scenario::{Self as test, Scenario, next_tx, ctx};
+use sui::clock::{Self, Clock};
+use sui::balance;
+use sui::coin;
+use sui::object; // For id_from_address
+
+use std::string::{Self, String};
+use std::vector;
+use std::option;
+use std::u256;
+
+use futarchy::proposal::{Self, Proposal};
+use futarchy::coin_escrow::{Self, TokenEscrow};
+use futarchy::fee::{Self, FeeManager};
+use futarchy::advance_stage;
+use futarchy::amm; // For get_oracle
+use futarchy::oracle as ft_oracle; // For get_total_cumulative_price
+
+// === Test-Specific Constants ===
+const ADMIN: address = @0xcafe;
+const DAO: address = @0xda0;
+
+const STARTING_TIMESTAMP: u64 = 1_000_000_000;
+
+const MIN_ASSET_LIQUIDITY_FOR_TEST: u64 = 1_000_000;
+const MIN_STABLE_LIQUIDITY_FOR_TEST: u64 = 1_000_000;
+
+const ONE_MINUTE_MS: u64 = 60_000;
+const ONE_HOUR_MS: u64 = 60 * ONE_MINUTE_MS;
+const ONE_DAY_MS: u64 = 24 * ONE_HOUR_MS;
+
+const TEST_REVIEW_PERIOD_MS: u64 = 12 * ONE_HOUR_MS;
+const TEST_TWAP_START_DELAY_MS: u64 = 2 * ONE_DAY_MS; // Must be multiple of ft_oracle::TWAP_PRICE_CAP_WINDOW
+const TEST_TRADING_PERIOD_MS: u64 = 5 * ONE_DAY_MS;
+
+const EXPECTED_TWAP_DURATION_MS: u64 = TEST_TRADING_PERIOD_MS - TEST_TWAP_START_DELAY_MS;
+
+const CONSTANT_PRICE_U128: u128 = 1_000_000_000_000u128; // Value of AMM price if reserves are 1:1 (amm::BASIS_POINTS)
+const TEST_TWAP_STEP_MAX: u64 = 1_000_000_000; // Large step to avoid capping with constant price
+const TEST_TWAP_THRESHOLD: u64 = 1; // Default, outcome 0 wins if no trades
+
+const STATE_REVIEW: u8 = 0;
+const STATE_TRADING: u8 = 1;
+const STATE_FINALIZED: u8 = 2;
+
+fun setup_test_proposal_for_oracle_check(
+    scenario: &mut Scenario,
+    clock: &Clock,
+) {
+    let asset_balance = balance::create_for_testing<u64>(MIN_ASSET_LIQUIDITY_FOR_TEST);
+    let stable_balance = balance::create_for_testing<u64>(MIN_STABLE_LIQUIDITY_FOR_TEST);
+    let dao_id = object::id_from_address(DAO);
+
+    let mut outcome_messages = vector::empty<String>();
+    vector::push_back(&mut outcome_messages, string::utf8(b"Outcome 0"));
+    vector::push_back(&mut outcome_messages, string::utf8(b"Outcome 1"));
+
+    let (_proposal_id, _market_state_id, _state) = proposal::create<u64, u64>(
+        dao_id,
+        2, // outcome_count
+        asset_balance,
+        stable_balance,
+        TEST_REVIEW_PERIOD_MS,
+        TEST_TRADING_PERIOD_MS,
+        MIN_ASSET_LIQUIDITY_FOR_TEST,
+        MIN_STABLE_LIQUIDITY_FOR_TEST,
+        string::utf8(b"Oracle TWAP Check Proposal"),
+        string::utf8(b"Details for oracle TWAP check"),
+        string::utf8(b"Metadata for oracle TWAP check"),
+        outcome_messages,
+        TEST_TWAP_START_DELAY_MS,
+        CONSTANT_PRICE_U128,
+        TEST_TWAP_STEP_MAX,
+        option::none<vector<u64>>(),
+        TEST_TWAP_THRESHOLD,
+        clock,
+        ctx(scenario),
+    );
+    fee::create_fee_manager_for_testing(ctx(scenario));
+}
+
+#[test]
+fun test_twap_accumulation_value_matches_expected_duration_constant_price() {
+    assert!(TEST_TRADING_PERIOD_MS > TEST_TWAP_START_DELAY_MS, 0); // Precondition for valid duration
+
+    let mut scenario = test::begin(ADMIN);
+    let mut clock = clock::create_for_testing(ctx(&mut scenario));
+    clock::set_for_testing(&mut clock, STARTING_TIMESTAMP);
+
+    let mut market_start_actual_time = 0;
+
+    // --- TX 1: Create Proposal ---
+    next_tx(&mut scenario, ADMIN);
+    {
+        setup_test_proposal_for_oracle_check(&mut scenario, &clock);
+    };
+
+    // --- TX 2: Advance to Trading State ---
+    let calculated_market_start_time = STARTING_TIMESTAMP + TEST_REVIEW_PERIOD_MS;
+    clock::set_for_testing(&mut clock, calculated_market_start_time);
+    market_start_actual_time = clock::timestamp_ms(&clock);
+    assert!(market_start_actual_time == calculated_market_start_time, 100);
+
+    next_tx(&mut scenario, ADMIN);
+    {
+        let mut proposal_obj = test::take_shared<Proposal<u64, u64>>(&scenario);
+        let mut escrow_obj = test::take_shared<TokenEscrow<u64, u64>>(&scenario);
+        let mut fee_manager_obj = test::take_shared<FeeManager>(&scenario);
+
+        advance_stage::try_advance_state_entry(
+            &mut proposal_obj, &mut escrow_obj, &mut fee_manager_obj, &clock,
+        );
+        assert!(proposal::state(&proposal_obj) == STATE_TRADING, 1);
+
+        test::return_shared(proposal_obj);
+        test::return_shared(escrow_obj);
+        test::return_shared(fee_manager_obj);
+    };
+
+    // --- TX 3: Advance to Finalized State ---
+    let finalization_time = market_start_actual_time + TEST_TRADING_PERIOD_MS;
+    clock::set_for_testing(&mut clock, finalization_time);
+    assert!(clock::timestamp_ms(&clock) == finalization_time, 101);
+
+    next_tx(&mut scenario, ADMIN);
+    {
+        let mut proposal_obj = test::take_shared<Proposal<u64, u64>>(&scenario);
+        let mut escrow_obj = test::take_shared<TokenEscrow<u64, u64>>(&scenario);
+        let mut fee_manager_obj = test::take_shared<FeeManager>(&scenario);
+
+        advance_stage::try_advance_state_entry(
+            &mut proposal_obj, &mut escrow_obj, &mut fee_manager_obj, &clock,
+        );
+        assert!(proposal::state(&proposal_obj) == STATE_FINALIZED, 2);
+
+        test::return_shared(proposal_obj);
+        test::return_shared(escrow_obj);
+        test::return_shared(fee_manager_obj);
+    };
+
+    // --- TX 4: Verification ---
+    next_tx(&mut scenario, ADMIN);
+    {
+        let mut proposal_obj = test::take_shared<Proposal<u64, u64>>(&scenario);
+        let pools = proposal::get_amm_pools(&proposal_obj);
+        let pool0 = vector::borrow(pools, 0);
+
+        let oracle_ref = amm::get_oracle(pool0);
+        let total_cumulative_price_val = ft_oracle::get_total_cumulative_price(oracle_ref);
+
+        let final_twaps_vec = proposal::get_twaps_for_proposal(&mut proposal_obj, &clock);
+        let average_price_val = *vector::borrow(&final_twaps_vec, 0);
+
+        assert!(average_price_val == CONSTANT_PRICE_U128, 3);
+
+        let calculated_duration_from_twap_parts = if (average_price_val == 0) {
+            0u256
+        } else {
+            total_cumulative_price_val / (average_price_val as u256)
+        };
+
+        std::debug::print(&b"Test: Oracle Full Flow TWAP Check");
+        std::debug::print(&b"Total Cumulative Price (Oracle)");
+        std::debug::print(&total_cumulative_price_val);
+        std::debug::print(&b"Average Price (TWAP from Proposal)");
+        std::debug::print(&average_price_val);
+        std::debug::print(&b"Calculated Duration from TWAP parts (ms)");
+        std::debug::print(&calculated_duration_from_twap_parts);
+        std::debug::print(&b"Expected TWAP Duration (ms)");
+        std::debug::print(&(EXPECTED_TWAP_DURATION_MS as u256));
+
+        assert!(
+            calculated_duration_from_twap_parts == (EXPECTED_TWAP_DURATION_MS as u256),
+            4
+        );
+
+        test::return_shared(proposal_obj);
+        let escrow_obj = test::take_shared<TokenEscrow<u64, u64>>(&scenario);
+        let fee_manager_obj = test::take_shared<FeeManager>(&scenario);
+        test::return_shared(escrow_obj);
+        test::return_shared(fee_manager_obj);
+    };
+
+    clock::destroy_for_testing(clock);
+    test::end(scenario);
+}

--- a/contracts/futarchy/tests/amm/oracle_integration_tests/oracle_price_cap_tests.move
+++ b/contracts/futarchy/tests/amm/oracle_integration_tests/oracle_price_cap_tests.move
@@ -16,13 +16,15 @@ const TWAP_PRICE_CAP_WINDOW_PERIOD: u64 = 60000;
 
 // ======== Helper Functions ========
 fun setup_test_oracle(ctx: &mut TxContext): Oracle {
-    oracle::new_oracle(
+    let mut oracle_inst = oracle::new_oracle(
         INIT_PRICE,
-        MARKET_START_TIME,
         TWAP_START_DELAY,
         TWAP_STEP_MAX,
         ctx,
-    )
+    );
+    // Explicitly set the market start time using the dedicated function
+    oracle::set_oracle_start_time(&mut oracle_inst, MARKET_START_TIME);
+    oracle_inst
 }
 
 fun setup_scenario_and_clock(): (Scenario, clock::Clock) {

--- a/contracts/futarchy/tests/amm/oracle_integration_tests/oracle_tests.move
+++ b/contracts/futarchy/tests/amm/oracle_integration_tests/oracle_tests.move
@@ -344,6 +344,8 @@ fun test_cumulative_price_overflow() {
     let ctx = test::ctx(&mut scenario);
     let mut extreme_oracle = oracle::new_oracle(u128::max_value!(), 0, U64_MAX, ctx);
 
+    oracle::set_oracle_start_time(&mut extreme_oracle, MARKET_START_TIME);
+
     // First observation: timestamp = U64_MAX / 2.
     let half_max: u64 = U64_MAX / 2;
     oracle::write_observation(&mut extreme_oracle, half_max, u128::max_value!());

--- a/contracts/futarchy/tests/amm/oracle_unit_tests/oracle_intra_window_accumulation_tests.move
+++ b/contracts/futarchy/tests/amm/oracle_unit_tests/oracle_intra_window_accumulation_tests.move
@@ -32,7 +32,6 @@ module futarchy::oracle_intra_accum_tests {
     fun setup_default_oracle(test_ctx: &mut TxContext): Oracle {
         oracle::new_oracle(
             DEFAULT_INIT_PRICE,
-            DEFAULT_MARKET_START_TIME,
             DEFAULT_TWAP_START_DELAY, // This delay is also the window size
             DEFAULT_TWAP_CAP_STEP,
             test_ctx,
@@ -257,7 +256,7 @@ module futarchy::oracle_intra_accum_tests {
         let test_ctx = ctx(&mut scenario);
         // Create oracle with a large cap step to ensure price isn't capped *beyond a single step from base* for this test
         let mut oracle_inst = oracle::new_oracle(
-            DEFAULT_INIT_PRICE, DEFAULT_MARKET_START_TIME, DEFAULT_TWAP_START_DELAY,
+            DEFAULT_INIT_PRICE, DEFAULT_TWAP_START_DELAY,
             u64::max_value!(), // Very large cap step
             test_ctx
         );

--- a/contracts/futarchy/tests/amm/oracle_unit_tests/oracle_multi_full_window_accumulation_tests.move
+++ b/contracts/futarchy/tests/amm/oracle_unit_tests/oracle_multi_full_window_accumulation_tests.move
@@ -34,7 +34,6 @@ module futarchy::oracle_multi_window_tests {
     ): Oracle {
         let mut oracle_inst = oracle::new_oracle(
             DEFAULT_INIT_PRICE,
-            MARKET_START_TIME_FOR_TESTS,
             0, // twap_start_delay, keep simple for these tests
             cap_step_val,
             ctx(scenario),

--- a/contracts/futarchy/tests/amm/oracle_unit_tests/oracle_twap_accumulate_tests.move
+++ b/contracts/futarchy/tests/amm/oracle_unit_tests/oracle_twap_accumulate_tests.move
@@ -31,7 +31,6 @@ module futarchy::oracle_twap_accumulate_tests {
         // as write_observation's delay logic is not the focus.
         oracle::new_oracle(
             INIT_PRICE,
-            MARKET_START_TIME,
             0, // twap_start_delay
             TWAP_CAP_STEP,
             test_ctx

--- a/contracts/futarchy/tests/amm/oracle_unit_tests/oracle_write_observation_tests.move
+++ b/contracts/futarchy/tests/amm/oracle_unit_tests/oracle_write_observation_tests.move
@@ -23,24 +23,23 @@ module futarchy::oracle_write_observation_tests {
 
     // ======== Helper Functions ========
     fun setup_test_oracle_custom(
-        market_start_time: u64,
         twap_start_delay: u64,
         init_price: u128,
         twap_cap_step: u64,
         ctx: &mut TxContext
     ): Oracle {
-        oracle::new_oracle(
+        let mut oracle_inst = oracle::new_oracle(
             init_price,
-            market_start_time,
             twap_start_delay,
             twap_cap_step,
             ctx,
-        )
+        );
+        oracle::set_oracle_start_time(&mut oracle_inst, MARKET_START_TIME);
+        oracle_inst
     }
 
     fun default_setup_test_oracle(ctx: &mut TxContext): Oracle {
         setup_test_oracle_custom(
-            MARKET_START_TIME,
             TWAP_START_DELAY,
             INIT_PRICE,
             TWAP_STEP_MAX,
@@ -471,7 +470,6 @@ module futarchy::oracle_write_observation_tests {
         let test_ctx = ctx(&mut scenario);
         // twap_start_delay = 0 means DELAY_THRESHOLD == MARKET_START_TIME
         let mut oracle_inst = setup_test_oracle_custom(
-            MARKET_START_TIME, // 100k
             0,                 // twap_start_delay
             INIT_PRICE,        // 10k
             TWAP_STEP_MAX,     // 1k


### PR DESCRIPTION
# Medium Bug

Bug allowing manipulation of TWAP.

TWAP start time was set to the proposal creation time. There is a TWAP delay, but that delay occurred at the same time as the pre-market period, as both were set to 12 hours, which mitigated the bug.

It would be a major more of these factors applied:
- Others had the liquidity to create a proposal 
- Another DAO that had a premarket period longer than its TWAP delay period
- Others  knew about this bug and chose to create AMM with very different starting price
- If the bug wasn't so obvious
- If they legally didn't have the right to ignore the governance contract on technical failures. 
- If someone forgot to crank the proposal to initialise trading, thereby increasing the effective premarket period.

Given this, it is being classed as a Medium. But if it isn't fixed, it could in other setups become a major bug.

<<img width="795" alt="image" src="https://github.com/user-attachments/assets/78a14a7c-8397-455c-ad2e-c32ff6e4c8af" />

# Why was it not picked up earlier
- I had limited fuzzing and unhappy path testing in integration tests. This required an integration test where the TWAP delay was less than the premarket time and a check of total TWAP accumulation time.
- AI and code reviews did not pick this up as the bug was spread across 6 files's behaviour and was in code changed in the last two weeks before launch.
- Sui Foundation denied audit sponsorship at this stage, as we didn't have customers a few weeks ago
- I had seen that the TWAP had weird behavior once, and had an open ticket to get more visibility on TWAP https://github.com/govex-dao/monorepo/issues/82. I do not have these doubts for any other parts of the code.
- I should have been using nullable values for TWAP start time and setting them when trading starts. This is added in this PR.
- This proposal was the ideal condition for spotting the bug as price initially moved up, monotonically, then flatlined for the rest of the period. 

<img width="1297" alt="image" src="https://github.com/user-attachments/assets/3b25456c-37c2-4dba-8c47-3ea3cc46f001" />


# Going forward
- 4 new tests added to check for this kind of issue
- Will ask AIs to review more than just a couple of files at a time
- Will keep a close eye on TWAP
- Will redeploy fix, as per the legal operating agreement V.2.1, this is allowed. https://github.com/govex-dao/monorepo/blob/main/legal/operating-agreement.md . This upgrade will preserve DAO ID and package ID.

