### PR TITLE
Fix slippage protection in swap transactions

### DIFF
--- a/frontend/src/components/trade/TradeForm.tsx
+++ b/frontend/src/components/trade/TradeForm.tsx
@@ -160,7 +160,7 @@ const TradeForm: React.FC<TradeFormProps> = ({
 
       setSwapDetails(breakdown);
       // Format based on the *output* token's decimals
-      setExpectedAmountOut(breakdown.exactAmountOut.toFixed(toToken.decimals));
+      setExpectedAmountOut(breakdown.minAmountOut.toFixed(toToken.decimals));
     } catch (error) {
       console.error("Swap calculation error:", error);
       toast.error(


### PR DESCRIPTION
## Summary
Fix critical bug in swap slippage protection by using `minAmountOut` instead of `exactAmountOut`.

## Bug Description
The frontend was passing `exactAmountOut` to the smart contract, which meant **zero slippage tolerance**. Any minor price movement would cause transactions to fail with `EExcessiveSlippage`.

## Fix
**File**: `frontend/src/components/trade/TradeForm.tsx:163`

**Before**:
```typescript
setExpectedAmountOut(breakdown.exactAmountOut.toFixed(toToken.decimals));
```

**After**:
```typescript
setExpectedAmountOut(breakdown.minAmountOut.toFixed(toToken.decimals));
```

## Technical Details
With 2% slippage (`DEFAULT_SLIPPAGE_BPS = 200`):
- `exactAmountOut` = 100 tokens (0% tolerance)
- `minAmountOut` = 98 tokens (2% tolerance)

Smart contract check: `assert!(amount_out >= min_amount_out, EExcessiveSlippage)`

**Before**: Fails if output is 99.8 tokens (99.8 < 100)
**After**: Succeeds with 99.8 tokens (99.8 >= 98)

## Impact
✅ Swaps now succeed with minor price movements
✅ Proper 2% slippage protection applied
✅ No more false `EExcessiveSlippage` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>